### PR TITLE
/add show error on invalid input

### DIFF
--- a/src/components/Error.astro
+++ b/src/components/Error.astro
@@ -1,0 +1,26 @@
+---
+interface Props {
+  id?: string;
+  active: boolean;
+}
+const { id, active } = Astro.props;
+---
+
+<style>
+  .error {
+    display: none;
+    border: 1px solid var(--error);
+    padding: 7px 12px;
+    width: 100%;
+    box-sizing: border-box;
+    border-radius: 1em;
+    white-space: pre-wrap;
+  }
+  .error[data-active="true"] {
+    display: block;
+  }
+</style>
+
+<div id={id} class="error" data-active={active}>
+  <slot />
+</div>

--- a/src/pages/add.astro
+++ b/src/pages/add.astro
@@ -1,5 +1,6 @@
 ---
 import BaseLayout from "@/layouts/BaseLayout.astro";
+import Error from "@/components/Error.astro";
 import Input from "@/components/Input.astro";
 ---
 
@@ -10,6 +11,7 @@ import Input from "@/components/Input.astro";
     let input = document.getElementById("md-input");
     // console.log(input.value);
     render.innerHTML = marked.parse(input.value);
+    validate();
   };
 
   const updateFileName = () => {
@@ -29,6 +31,43 @@ import Input from "@/components/Input.astro";
   // };
 </script>
 <script lang="javascript">
+ const validate = () => {
+    let submitButton = document.getElementById("submit");
+    let errorContainer = document.getElementById("error-div");
+    let errorText = document.getElementById("error-message");
+    let error = findInputError();
+
+    if (error === undefined) {
+      submitButton.disabled = false;
+      errorContainer.dataset.active = false;
+      return
+    };
+    submitButton.disabled = true;
+    errorContainer.dataset.active = true;
+    errorText.innerText = "Error: "+error;
+  };
+  const findInputError = () => {
+    let form = document.getElementById("form");
+    for (const input of form.elements) {
+      if (input.required && input.value === "") return `"${input.name}" field must be provided`;
+    };
+
+    let text = document.getElementById("md-input").value;
+    if (text === "") return `Text must not be empty`;
+    const banned_words = [
+      [/(<br ?\/?>)/, "Text should use markdown not HTML, \n\"toki$1toki\"\ncan be written as \n\"toki\\\ntoki\"\nor\n\"toki  \ntoki\"\n(with two spaces)"],
+      [/<\/p>/, "Text should use markdown not HTML, \n\"<p>toki open</p><p>toki pini</p>\"\ncan be written as \n\"toki open\ntoki pini\"\n"],
+      [/<\/(i|em)>/, "Text should use markdown not HTML, \"<$1>toki</$1>\" can be written as \"*toki*\""],
+      [/<\/(b|strong)>/, "Text should use markdown not HTML, \"<$1>toki</$1>\" can be written as \"**toki**\""],
+      [/<a href="?([^">]+)"?>/, "Text should use markdown not HTML, \"<a href=\"$1\">lipu</a>\" can be written as \"[lipu]($1)\""],
+    ];
+    for (const [word, error] of banned_words) {
+      let match = text.match(word);
+      if (match === null) continue;
+      return error.replaceAll("$1", match[1]);
+    };
+  };
+  
   const submit = async () => {
     let form = document.getElementById("form");
     let data = {
@@ -66,13 +105,21 @@ import Input from "@/components/Input.astro";
         `Your article has been received and will be reviewed by volunteers!<br /><a href="${responseBody.data.html_url}">${responseBody.data.title}</a><br />Please make sure not to submit the same thing several times, thanks in advance!`;
       document.getElementById("response-error").innerHTML = "";
     } else {
-      document.getElementById("response").innerHTML =
-        `Failed to upload article. Show this to kala Asi at ma pona! Error message:`;
-      document.getElementById("response-error").innerHTML =
-        `${JSON.stringify(responseBody.error, null, " ")}`;
+      document.getElementById("error-message").innerHTML = 
+        `Failed to upload article. Show this to kala Asi at ma pona! Error message:
+        <pre>\n${JSON.stringify(responseBody.error, null, " ")}</pre>`
+      document.getElementById("error-div").dataset.active = true;
+      submitButton.active = false;
     }
     submitButton.value = "Submit article";
     submitButton.onclick = submit;
+  };
+
+  const ignoreError = () => {
+    let submitButton = document.getElementById("submit");
+    let errorContainer = document.getElementById("error-div");
+    errorContainer.dataset.active = false;
+    submitButton.disabled = false;
   };
 
   // document.getElementById("form").addEventListener("submit", (e) => {
@@ -92,7 +139,7 @@ import Input from "@/components/Input.astro";
 <BaseLayout title={"Add an article"}>
   <section>
     <h1>Add your article</h1>
-    <form id="form">
+    <form id="form" oninput="validate()">
       <div class="row">
         <Input
           top
@@ -122,7 +169,6 @@ import Input from "@/components/Input.astro";
         <Input
           title="Original title"
           id="original-title"
-          required
           placeholder="carry-feat-jan-kekan-san"
           placeholder="(use this if the work is a translation)"
         />
@@ -131,13 +177,11 @@ import Input from "@/components/Input.astro";
         <Input
           title="Authors"
           id="authors"
-          required
           placeholder="jan Usawi, jan Kekan San"
         />
         <Input
           title="Original authors"
           id="original-authors"
-          required
           placeholder="(use this if the work is a translation)"
         />
       </div>
@@ -150,7 +194,7 @@ import Input from "@/components/Input.astro";
       </div>
       <div class="row">
         <Input title="Date published" id="date" type="date" required />
-        <Input title="Date precision" id="date-precision" tag="select">
+        <Input title="Date precision" id="date-precision" tag="select" required>
           <option selected value="day">Precise to the day</option>
           <option value="month">Precise to the month</option>
           <option value="year">Precise to the year</option>
@@ -165,6 +209,7 @@ import Input from "@/components/Input.astro";
         <Input
           title="Sources"
           id="sources"
+          required
           placeholder="https://janusawi.bandcamp.com/album/toki-gaming"
         />
       </div>
@@ -199,6 +244,9 @@ import Input from "@/components/Input.astro";
       oninput="rerender()"></textarea>
   </div>
   <div id="md-render"></div>
+  <Error id="error-div" active={false}><span id="error-message"></span>
+    <br><button class="ignore_error" onclick="ignoreError()">I know what I'm doing, ignore this</button>
+  </Error>
   <input
     class="submit"
     type="submit"
@@ -214,20 +262,30 @@ import Input from "@/components/Input.astro";
   .row {
     display: flex;
   }
-  .submit {
+  .submit, .ignore_error {
     font-size: inherit;
     font-family: inherit;
     color: inherit;
-    display: block;
-    border: 1px solid var(--grey-1);
-    padding: 10px 40px;
-    font-weight: bold;
-    border-radius: 10px;
-    margin: 10px auto;
     background-color: var(--bg);
+    border: 1px solid var(--grey-1);
+    border-radius: 10px;
   }
-  .submit:hover {
+  .submit {
+    font-weight: bold;
+    padding: 10px 40px;
+    display: block;
+    margin: 10px auto;
+  }
+  .ignore_error {
+    font-style: italic;
+    padding: 0.5em 1em;
+  }
+  .submit:hover, .ignore_error:hover {
     background-color: var(--bg-1);
+  }
+  .submit:disabled {
+    background-color: var(--grey-1);
+    cursor: not-allowed;
   }
   textarea {
     box-sizing: border-box;

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -5,6 +5,7 @@
     --grey: #999;
     --grey-1: #bbb;
     --accent: #0068d3;
+    --error: #e61023;
 }
 .dark {
     --bg: #0f0f0f;
@@ -13,6 +14,7 @@
     --grey: #666;
     --grey-1: #444;
     --accent: #49a3ff;
+    --error: #ff495a;
 }
 
 body {


### PR DESCRIPTION
This PR changes the /add page, to show what's wrong before you try to submit. It checks for missing fields and use of HTML tags when markdown suffices.

![image](https://github.com/user-attachments/assets/a578349c-b234-445b-854e-122985831a72)

Every time an input is changed, it'll ensure that all required fields (indicated with the required attribute, set on all non-nullable fields in [validate-schema.ts](https://github.com/kulupu-lapo/poki/blob/a582abf1543b3060ab192522695c66a9f1e02e3b/utils/validate/validate-schemas.ts)) are filled in, otherwise it disables the  'submit' button.

It'll also check that the user doesn't use any \<p\>, \<br\>, \<b\>, \<i\> or plain \<a href="..."\> tags, recommending the markdown equivalent.

Compare :![image](https://github.com/user-attachments/assets/5c58e341-2518-4751-abda-603e3cdfc4da)
vs the corrected: ![image](https://github.com/user-attachments/assets/d289fa95-eb0b-439e-b22d-b9aa9bb3112a)

The user can choose to ignore these errors, and reenable the submit button. If the server receives an invalid input it'll display this like before but in the new error box.
![image](https://github.com/user-attachments/assets/8813aa06-75d4-4196-bb74-df954cf10222)
