### PR TITLE
Display 'original' field and group other adaptations

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -33,6 +33,7 @@ import DarkModeToggle from "@/components/DarkModeToggle.astro";
   <a href="./collections">Collections</a>{" · "}
   <a href="./tags">Tags</a>{" · "}
   <a href="./authors">Authors</a>{" · "}
+  <a href="./translations">Translations</a>{" · "}
   <a href="./random">Random</a>{" · "}
   <a href="./add">Add</a>
 </header>

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -33,7 +33,7 @@ import DarkModeToggle from "@/components/DarkModeToggle.astro";
   <a href="./collections">Collections</a>{" · "}
   <a href="./tags">Tags</a>{" · "}
   <a href="./authors">Authors</a>{" · "}
-  <a href="./translations">Translations</a>{" · "}
+  <a href="./adaptations">Adaptations</a>{" · "}
   <a href="./random">Random</a>{" · "}
   <a href="./add">Add</a>
 </header>

--- a/src/components/Metadata.astro
+++ b/src/components/Metadata.astro
@@ -69,6 +69,25 @@ const { post } = Astro.props;
     )
   }
   {
+    post.original && (
+      <p>
+        <span>Original:</span>
+        <span>{post.original.title}</span>
+        {
+          post.original.authors && (
+            <span>
+              by {post.original.authors.reduce((prev, curr, i) => (
+                <>
+                  {prev}, {curr}
+                </>
+              ))}
+            </span>
+          )
+        }
+      </p>
+    ) 
+  }
+  {
     (post.preprocessing || post["accessibility-notes"] || post.notes) && (
       <p>
         <span>Notes:</span>

--- a/src/components/Metadata.astro
+++ b/src/components/Metadata.astro
@@ -69,10 +69,10 @@ const { post } = Astro.props;
     )
   }
   {
-    post.original && (
+    post.original && post.original.title !== null &&  (
       <p>
         <span>Original:</span>
-        <span>{post.original.title}</span>
+        <a href={`./o/${escape(post.original.title)}`}>{post.original.title}</a>
         {
           post.original.authors && (
             <span>

--- a/src/components/PrevNexts.astro
+++ b/src/components/PrevNexts.astro
@@ -16,7 +16,7 @@ const humanReadable = (string: string) => {
   if (string.slice(0, 2) === "a/") return `by ${unescape(string.slice(2))}`;
   if (string.slice(0, 2) === "c/") return `from ${unescape(string.slice(2))}`;
   if (string.slice(0, 2) === "t/") return `${unescape(string.slice(2))}`;
-  if (string.slice(0, 2) === "o/") return `translating ${unescape(string.slice(2))}`;
+  if (string.slice(0, 2) === "o/") return `adapting ${unescape(string.slice(2))}`;
   return string;
 };
 

--- a/src/components/PrevNexts.astro
+++ b/src/components/PrevNexts.astro
@@ -16,6 +16,7 @@ const humanReadable = (string: string) => {
   if (string.slice(0, 2) === "a/") return `by ${unescape(string.slice(2))}`;
   if (string.slice(0, 2) === "c/") return `from ${unescape(string.slice(2))}`;
   if (string.slice(0, 2) === "t/") return `${unescape(string.slice(2))}`;
+  if (string.slice(0, 2) === "o/") return `translating ${unescape(string.slice(2))}`;
   return string;
 };
 

--- a/src/pages/adaptations.astro
+++ b/src/pages/adaptations.astro
@@ -10,7 +10,7 @@ import { escape, postsByOriginal } from "@/utils/content";
     {
       postsByOriginal.map((row) => (
         <li>
-          <a href={`./o/${escape(row.original)}`}>{row.original}</a>
+          <a href={`./o/${escape(row.original)}`}>{row.original}{row.authors.length > 0 && " (" + row.authors.join(', ') + ")" }</a>
           {` (${row.posts.length} adaptations)`}
         </li>
       ))

--- a/src/pages/adaptations.astro
+++ b/src/pages/adaptations.astro
@@ -5,13 +5,13 @@ import { escape, postsByOriginal } from "@/utils/content";
 ---
 
 <BaseLayout title="authors">
-  <h2>Translation sources ({postsByOriginal.length})</h2>
+  <h2>Adaptation sources ({postsByOriginal.length})</h2>
   <ul>
     {
       postsByOriginal.map((row) => (
         <li>
           <a href={`./o/${escape(row.original)}`}>{row.original}</a>
-          {` (${row.posts.length} posts)`}
+          {` (${row.posts.length} adaptations)`}
         </li>
       ))
     }

--- a/src/pages/o/[original_title].astro
+++ b/src/pages/o/[original_title].astro
@@ -1,0 +1,24 @@
+---
+import BaseLayout from "@/layouts/BaseLayout.astro";
+
+import FoundPost from "@/components/FoundPost.astro";
+import { originals, getAuthorsOfOriginal, escape, getPostsByOriginal, unescape } from "@/utils/content";
+
+export async function getStaticPaths() {
+  return originals.map((original) => ({
+    params: { original_title: escape(original) },
+    props: { posts: getPostsByOriginal(original) },
+  }));
+}
+
+const { original_title } = Astro.params;
+const { posts } = Astro.props;
+const authors = getAuthorsOfOriginal(unescape(original_title))
+---
+
+<BaseLayout title={unescape(original_title)}>
+  <h2>Translations of {unescape(original_title)} { authors.length > 0 && (<>by {authors.join(', ')}</>)} ({posts.length})</h2>
+  <ul>
+    {posts.map((post) => <FoundPost {post} query={`o/${original_title}`} />)}
+  </ul>
+</BaseLayout>

--- a/src/pages/o/[original_title].astro
+++ b/src/pages/o/[original_title].astro
@@ -17,7 +17,7 @@ const authors = getAuthorsOfOriginal(unescape(original_title))
 ---
 
 <BaseLayout title={unescape(original_title)}>
-  <h2>Translations of {unescape(original_title)} { authors.length > 0 && (<>by {authors.join(', ')}</>)} ({posts.length})</h2>
+  <h2>Adaptations of {unescape(original_title)} { authors.length > 0 && (<>by {authors.join(', ')}</>)} ({posts.length})</h2>
   <ul>
     {posts.map((post) => <FoundPost {post} query={`o/${original_title}`} />)}
   </ul>

--- a/src/pages/translations.astro
+++ b/src/pages/translations.astro
@@ -1,0 +1,19 @@
+---
+import BaseLayout from "@/layouts/BaseLayout.astro";
+
+import { escape, postsByOriginal } from "@/utils/content";
+---
+
+<BaseLayout title="authors">
+  <h2>Translation sources ({postsByOriginal.length})</h2>
+  <ul>
+    {
+      postsByOriginal.map((row) => (
+        <li>
+          <a href={`./o/${escape(row.original)}`}>{row.original}</a>
+          {` (${row.posts.length} posts)`}
+        </li>
+      ))
+    }
+  </ul>
+</BaseLayout>

--- a/src/utils/content.ts
+++ b/src/utils/content.ts
@@ -43,7 +43,7 @@ export const postsByAuthor = authors
 export const originals = [
   ...new Set(posts.filter((post) => post.data.original !== null && post.data.original.title !== null)
                   .map((post) => post.data.original!.title!)),
-]
+].sort()
 
 export const getAuthorsOfOriginal = (original: string) => [...new Set(
   posts.filter(

--- a/src/utils/content.ts
+++ b/src/utils/content.ts
@@ -39,6 +39,30 @@ export const postsByAuthor = authors
   }))
   .sort(by((x) => x.posts.length, false));
 
+// originals (indexed by .original.title)
+export const originals = [
+  ...new Set(posts.filter((post) => post.data.original !== null && post.data.original.title !== null)
+                  .map((post) => post.data.original!.title!)),
+]
+
+export const getAuthorsOfOriginal = (original: string) => [...new Set(
+  posts.filter(
+    (post) => post.data.original && post.data.original.title === original && post.data.original.authors !== null
+  ).flatMap((post) => post.data.original!.authors)
+)];
+
+export const getPostsByOriginal = (original: string) =>
+  posts.filter(
+    (post) => post.data.original && post.data.original.title === original,
+  );
+
+export const postsByOriginal = originals
+  .map((original) => ({
+    original,
+    posts: getPostsByOriginal(original),
+  }))
+  .sort(by((x) => x.posts.length, false));
+
 // tags
 
 export const tags = [

--- a/src/utils/content.ts
+++ b/src/utils/content.ts
@@ -49,6 +49,7 @@ export const getAuthorsOfOriginal = (original: string) => [...new Set(
   posts.filter(
     (post) => post.data.original && post.data.original.title === original && post.data.original.authors !== null
   ).flatMap((post) => post.data.original!.authors)
+  .filter(author => author !== "unknown" && author !== "(unknown)")
 )];
 
 export const getPostsByOriginal = (original: string) =>

--- a/src/utils/content.ts
+++ b/src/utils/content.ts
@@ -156,5 +156,14 @@ export const prevnexts = (() => {
     });
   });
 
+  postsByOriginal.map(({ original, posts: arrayPosts }, i) => {
+    arrayPosts.map((post, j) => {
+      prevnexts[post.id][`o/${escape(original)}`] = {
+        prev: arrayPosts[j - 1],
+        next: arrayPosts[j + 1],
+      };
+    });
+  });
+
   return prevnexts;
 })();

--- a/src/utils/content.ts
+++ b/src/utils/content.ts
@@ -60,6 +60,7 @@ export const postsByOriginal = originals
   .map((original) => ({
     original,
     posts: getPostsByOriginal(original),
+    authors: getAuthorsOfOriginal(original),
   }))
   .sort(by((x) => x.posts.length, false));
 


### PR DESCRIPTION
# Changes
- Display the 'original' metadata field on relevant pages
![image](https://github.com/user-attachments/assets/6a707dba-3196-437f-b866-5c289ac80e5a)
- Add a page for each unique listed source (based on title alone, currently all instances where the original has the same title but a different author is in fact referring to the same piece of work)
![image](https://github.com/user-attachments/assets/5c3d39f3-ec66-4508-9bd0-34a526e5439c)
- Add an 'adaptations' page (shown in the nav bar), listing all these pages.
![image](https://github.com/user-attachments/assets/9a87cdbb-78c5-4baf-b13b-b72c859ec7ff)
- Update the prev/next bar for browsing other adaptations
![image](https://github.com/user-attachments/assets/ce62d1ca-5fe1-4596-86c8-a7fbffa758d5)

# Considerations
- This clutters the nav bar a little.  
- Should we bother showing an index in the prev/next if the current work is the only one with that tag/author/collection/adaptation?  
- We need a better way of handling when the original is another work in Lapo. 
  - Giving some more information, perhaps just a link, for the orginal would also be helpful for locating non-Lapo works
- It might be nice to browse adaptations of all works by a specific author