### PR TITLE
[patch] fix /random (when language is unspecified)

### DIFF
--- a/src/components/PrevNexts.astro
+++ b/src/components/PrevNexts.astro
@@ -110,11 +110,11 @@ const { prevnexts, langPrefix } = Astro.props;
   const updatePage = () => {
     const prevnext = prevnexts[getQuery()];
     navSelect.value = getQuery();
-    const lang = navSelect.dataset.langprefix || '.';
+    const langprefix = navSelect.dataset.langprefix || '';
 
     const prev = document.getElementById("nav-prev-link")!;
     if (prevnext.prev) {
-      prev.setAttribute("href", `${lang}/${prevnext.prev?.id}?q=${getQuery()}`);
+      prev.setAttribute("href", `${langprefix}${prevnext.prev?.id}?q=${getQuery()}`);
       prev.innerText = `« ${abbreviate(prevnext.prev?.data.title)}`;
     } else {
       prev.innerText = "";
@@ -122,7 +122,7 @@ const { prevnexts, langPrefix } = Astro.props;
 
     const next = document.getElementById("nav-next-link")!;
     if (prevnext.next) {
-      next.setAttribute("href", `${lang}/${prevnext.next?.id}?q=${getQuery()}`);
+      next.setAttribute("href", `${langprefix}${prevnext.next?.id}?q=${getQuery()}`);
       next.innerText = `${abbreviate(prevnext.next?.data.title)} »`;
     } else {
       next.innerText = "";

--- a/src/pages/[...lang]/[...slug].astro
+++ b/src/pages/[...lang]/[...slug].astro
@@ -45,7 +45,7 @@ const { Content } = await render(post);
     <center>{formatDate(post.data.date, post.data["date-precision"], post.lang)}</center>
 
     <!-- <PrevNexts client:load prevnexts={prevnexts[post.id]} /> -->
-    <PrevNexts prevnexts={prevnext} langPrefix={Astro.url.pathname.startsWith('/'+post.lang) ? post.lang : '.' } />
+    <PrevNexts prevnexts={prevnext} langPrefix={Astro.props.langPrefix} />
 
     {embed && <Embed id={embed} />}
     <section lang={post.lang === "tok" ? undefined : "tok"}>

--- a/src/pages/[...lang]/random.astro
+++ b/src/pages/[...lang]/random.astro
@@ -19,11 +19,9 @@ const links = posts.map((post) => `${import.meta.env.BASE_URL}${langPrefix}${pos
     <script is:inline src="./light-mode.js"></script>
   </head>
   <body>
-    <span style="display: none" id="links">{JSON.stringify(links)}</span>
-    <script lang="javascript">
-      const urls = JSON.parse(document.getElementById("links").textContent);
-      var randURL = Math.floor(Math.random() * urls.length);
-      window.open(urls[randURL], "_self");
+    <script define:vars={{links}} lang="javascript">
+      var randURL = Math.floor(Math.random() * links.length);
+      window.open(links[randURL], "_self");
     </script>
     <span>Redirecting...</span>
   </body>

--- a/src/utils/i18n.ts
+++ b/src/utils/i18n.ts
@@ -10,7 +10,7 @@ const i18n_prefixes = locales.map( locale => ({ locale: locale, prefix: locale a
 
 export async function getStaticLanguagePaths() {
   return i18n_prefixes.map(({locale, prefix}) => {
-    return { params: { lang: prefix }, props: { lang: locale, langPrefix: prefix === undefined ? undefined : prefix + '/' }, };
+    return { params: { lang: prefix }, props: { lang: locale, langPrefix: prefix === undefined ? '' : prefix + '/' }, };
   });
 }
 

--- a/src/utils/i18n.ts
+++ b/src/utils/i18n.ts
@@ -23,6 +23,7 @@ export function internationaliseStaticPaths<T,E>(paths : {params: T, props: E}[]
             },
             props: {
                 lang: locale,
+                langPrefix: prefix === undefined ? '' : prefix + '/',
                 ...props
             }
         }))


### PR DESCRIPTION
Currently, visiting /random with a url that doesn't specify a language, eg https://lipu.pona.la/random/, will result in a redirect to a 404 page with the URL containing an erroneously 'undefined', eg https://lipu.pona.la/undefined2020/11/mu. This PR fixes that.

The source of this bug is that /random.astro generates its urls with `` `${import.meta.env.BASE_URL}${langPrefix}${post.id}` ``  (due to https://github.com/kulupu-lapo/lipu/commit/819cdfd1500b8d54c5be312e45d587c648241d55#diff-7f0d0d8a1926ce689fe5ed4891c82104fb4542f623318de7dc9b0facea9e7611), which was fine at the time, but https://github.com/kulupu-lapo/lipu/commit/b3951c0c68637c7f16fd6ce67dc9f915ea8f1a62 changed `langPrefix` from a `string` to a `string | undefined` (substituting `langPrefix=''` for `langPrefix=undefined`).

This PR rectifies this by ensuring `langPrefix` is always a `string`, setting it to `''` instead of `undefined` as it is generated in `utils/i18n.ts`. The reason for the initial change was to have `Astro.params.lang` be `undefined` when the language portion of the URL is empty, which is preserved in this PR; letting `langPrefix` be undefined too was an oversight.
The only other place `langPrefix` is referenced is with regards to the `PrevNext` component. This previously used a slightly different definition where it would take values in `"." | "en" | "tok"` rather than `undefined | "en/" | "tok/"`, so it wasn't affected by this bug. For cohesiveness, this PR changes PrevNext's langPrefix prop (= the client side js' `langprefix`) to match the one generated by `utils/i18n.ts`

This also modifies the random.astro file to use the [define:vars directive](https://docs.astro.build/en/reference/directives-reference/#definevars), rather than inserting it as hidden HTML text that gets JSON.parse()d, this has no effect on functionality but makes for cleaner code.